### PR TITLE
Fix table name in model & tests

### DIFF
--- a/src/Models/Patch.php
+++ b/src/Models/Patch.php
@@ -40,4 +40,14 @@ class Patch extends Model
     protected $casts = [
         'log' => 'array',
     ];
+
+    /**
+     * Get the table associated with the model.
+     *
+     * @return string
+     */
+    public function getTable()
+    {
+        return config('laravel-patches.table_name');
+    }
 }

--- a/tests/Commands/PatchTest.php
+++ b/tests/Commands/PatchTest.php
@@ -14,13 +14,13 @@ class PatchTest extends TestCase
             file_get_contents(__DIR__.'/patches/2021_01_01_000000_my_first_patch.php')
         );
 
-        $this->assertDatabaseCount('patches', 0);
+        $this->assertDatabaseCount(config('laravel-patches.table_name'), 0);
 
         $this->artisan('patch')->run();
 
-        $this->assertDatabaseCount('patches', 1);
+        $this->assertDatabaseCount(config('laravel-patches.table_name'), 1);
 
-        $this->assertDatabaseHas('patches', [
+        $this->assertDatabaseHas(config('laravel-patches.table_name'), [
             'patch' => '2021_01_01_000000_my_first_patch',
             'batch' => 1,
             'log' => json_encode(['Hello First!']),
@@ -37,7 +37,7 @@ class PatchTest extends TestCase
 
         $this->artisan('patch')->run();
 
-        $this->assertDatabaseHas('patches', [
+        $this->assertDatabaseHas(config('laravel-patches.table_name'), [
             'patch' => '2021_01_01_000000_my_first_patch',
             'batch' => 1,
         ]);
@@ -49,7 +49,7 @@ class PatchTest extends TestCase
 
         $this->artisan('patch')->run();
 
-        $this->assertDatabaseHas('patches', [
+        $this->assertDatabaseHas(config('laravel-patches.table_name'), [
             'patch' => '2021_01_02_000000_my_second_patch',
             'batch' => 2,
         ]);
@@ -70,13 +70,13 @@ class PatchTest extends TestCase
 
         $this->artisan('patch')->run();
 
-        $this->assertDatabaseHas('patches', [
+        $this->assertDatabaseHas(config('laravel-patches.table_name'), [
             'id' => 1,
             'patch' => '2021_01_01_000000_my_first_patch',
             'batch' => 1,
         ]);
 
-        $this->assertDatabaseHas('patches', [
+        $this->assertDatabaseHas(config('laravel-patches.table_name'), [
             'id' => 2,
             'patch' => '2021_01_02_000000_my_second_patch',
             'batch' => 1,
@@ -98,13 +98,13 @@ class PatchTest extends TestCase
 
         $this->artisan('patch', ['--step' => true])->run();
 
-        $this->assertDatabaseHas('patches', [
+        $this->assertDatabaseHas(config('laravel-patches.table_name'), [
             'id' => 1,
             'patch' => '2021_01_01_000000_my_first_patch',
             'batch' => 1,
         ]);
 
-        $this->assertDatabaseHas('patches', [
+        $this->assertDatabaseHas(config('laravel-patches.table_name'), [
             'id' => 2,
             'patch' => '2021_01_02_000000_my_second_patch',
             'batch' => 2,

--- a/tests/Commands/RollbackTest.php
+++ b/tests/Commands/RollbackTest.php
@@ -17,22 +17,22 @@ class RollbackTest extends TestCase
             file_get_contents(__DIR__.'/patches/2021_01_01_000000_my_first_patch.php')
         );
 
-        $this->assertDatabaseCount('patches', 0);
+        $this->assertDatabaseCount(config('laravel-patches.table_name'), 0);
 
         $this->artisan('patch')->run();
 
-        $this->assertDatabaseCount('patches', 1);
+        $this->assertDatabaseCount(config('laravel-patches.table_name'), 1);
 
-        $this->assertDatabaseHas('patches', [
+        $this->assertDatabaseHas(config('laravel-patches.table_name'), [
             'patch' => '2021_01_01_000000_my_first_patch',
             'batch' => 1,
         ]);
 
         $this->artisan('patch:rollback')->run();
 
-        $this->assertDatabaseCount('patches', 0);
+        $this->assertDatabaseCount(config('laravel-patches.table_name'), 0);
 
-        $this->assertDatabaseMissing('patches', [
+        $this->assertDatabaseMissing(config('laravel-patches.table_name'), [
             'patch' => '2021_01_01_000000_my_first_patch',
             'batch' => 1,
         ]);
@@ -56,11 +56,11 @@ class RollbackTest extends TestCase
 
         $this->artisan('patch')->run();
 
-        $this->assertDatabaseCount('patches', 2);
+        $this->assertDatabaseCount(config('laravel-patches.table_name'), 2);
 
         $this->artisan('patch:rollback')->run();
 
-        $this->assertDatabaseCount('patches', 0);
+        $this->assertDatabaseCount(config('laravel-patches.table_name'), 0);
     }
 
     /** @test */
@@ -80,24 +80,24 @@ class RollbackTest extends TestCase
 
         $this->artisan('patch')->run();
 
-        $this->assertDatabaseHas('patches', [
+        $this->assertDatabaseHas(config('laravel-patches.table_name'), [
             'patch' => '2021_01_01_000000_my_first_patch',
             'batch' => 1,
         ]);
 
-        $this->assertDatabaseHas('patches', [
+        $this->assertDatabaseHas(config('laravel-patches.table_name'), [
             'patch' => '2021_01_02_000000_my_second_patch',
             'batch' => 1,
         ]);
 
         $this->artisan('patch:rollback', ['--step' => 1])->run();
 
-        $this->assertDatabaseHas('patches', [
+        $this->assertDatabaseHas(config('laravel-patches.table_name'), [
             'patch' => '2021_01_01_000000_my_first_patch',
             'batch' => 1,
         ]);
 
-        $this->assertDatabaseMissing('patches', [
+        $this->assertDatabaseMissing(config('laravel-patches.table_name'), [
             'patch' => '2021_01_02_000000_my_second_patch',
             'batch' => 1,
         ]);


### PR DESCRIPTION
#3 added ability to specify table name but it does not work because patch model still uses default table name (i.e. 'patches').
This PR will fix it.