### PR TITLE
Update stubs to generate anonymous classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "spatie/laravel-package-tools": "^1.1",
         "illuminate/contracts": "^10.0"
     },

--- a/database/migrations/create_patches_table.php.stub
+++ b/database/migrations/create_patches_table.php.stub
@@ -4,14 +4,11 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class CreatePatchesTable extends Migration
-{
+return new class extends Migration {
     /**
      * Run the migrations.
-     *
-     * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::create(config('laravel-patches.table_name'), function (Blueprint $table) {
             $table->id();
@@ -24,11 +21,9 @@ class CreatePatchesTable extends Migration
 
     /**
      * Reverse the migrations.
-     *
-     * @return void
      */
-    public function down()
+    public function down(): void
     {
         Schema::dropIfExists(config('laravel-patches.table_name'));
     }
-}
+};

--- a/src/Commands/PatchCommand.php
+++ b/src/Commands/PatchCommand.php
@@ -33,32 +33,9 @@ class PatchCommand extends Command
      */
     protected $description = 'Run any necessary patches';
 
-    /**
-     * The patcher instance.
-     *
-     * @var Patcher
-     */
-    protected Patcher $patcher;
-
-    /**
-     * The repository instance.
-     *
-     * @var Repository
-     */
-    protected Repository $repository;
-
-    /**
-     * PatchCommand constructor.
-     *
-     * @param  Patcher  $patcher
-     * @param  Repository  $repository
-     */
-    public function __construct(Patcher $patcher, Repository $repository)
+    public function __construct(protected Patcher $patcher, protected Repository $repository)
     {
         parent::__construct();
-
-        $this->patcher = $patcher;
-        $this->repository = $repository;
     }
 
     /**
@@ -91,10 +68,10 @@ class PatchCommand extends Command
     /**
      * Get the patch files that have not yet run.
      *
-     * @param  array  $files
-     * @param  array  $ran
+     * @param  string[]  $files
+     * @param  string[]  $ran
      *
-     * @return array
+     * @return string[]
      */
     protected function pendingPatches(array $files, array $ran): array
     {
@@ -106,7 +83,7 @@ class PatchCommand extends Command
     /**
      * Run pending patches
      *
-     * @param  array  $patches
+     * @param  string[]  $patches
      */
     protected function runPending(array $patches): void
     {
@@ -130,10 +107,10 @@ class PatchCommand extends Command
     /**
      * Run the up method on the patch
      *
-     * @param $file
+     * @param  string $file
      * @param  int  $batch
      */
-    protected function runUp($file, int $batch): void
+    protected function runUp(string $file, int $batch): void
     {
         $patch = $this->patcher->resolve($file);
 

--- a/src/Commands/PatchCommand.php
+++ b/src/Commands/PatchCommand.php
@@ -135,7 +135,9 @@ class PatchCommand extends Command
      */
     protected function runUp($file, int $batch): void
     {
-        $patch = $this->patcher->resolve($name = $this->patcher->getPatchName($file));
+        $patch = $this->patcher->resolve($file);
+
+        $name = $this->patcher->getPatchName($file);
 
         $this->line("<comment>Running Patch:</comment> {$name}");
 

--- a/src/Commands/PatchMakeCommand.php
+++ b/src/Commands/PatchMakeCommand.php
@@ -31,41 +31,12 @@ class PatchMakeCommand extends Command
      */
     protected $description = 'Create a patch file';
 
-    /**
-     * The patcher instance.
-     *
-     * @var Patcher
-     */
-    protected Patcher $patcher;
-
-    /**
-     * The Composer instance.
-     *
-     * @var Composer
-     */
-    protected Composer $composer;
-
-    /**
-     * The filesystem instance.
-     *
-     * @var Filesystem
-     */
-    protected Filesystem $files;
-
-    /**
-     * Create a new command instance.
-     *
-     * @param  Patcher  $patcher
-     * @param  Composer  $composer
-     * @param  Filesystem  $files
-     */
-    public function __construct(Patcher $patcher, Composer $composer, Filesystem $files)
-    {
+    public function __construct(
+        protected Patcher $patcher,
+        protected Composer $composer,
+        protected Filesystem $files
+    ) {
         parent::__construct();
-
-        $this->patcher = $patcher;
-        $this->composer = $composer;
-        $this->files = $files;
     }
 
     /**
@@ -100,13 +71,13 @@ class PatchMakeCommand extends Command
     /**
      * Create the patch and return the path
      *
-     * @param $name
-     * @param $path
+     * @param  string $name
+     * @param  string $path
      *
      * @return string
      * @throws FileNotFoundException
      */
-    protected function create($name, $path): string
+    protected function create(string $name, string $path): string
     {
         $this->ensurePatchDoesntAlreadyExist($name);
 
@@ -124,11 +95,11 @@ class PatchMakeCommand extends Command
     /**
      * Make sure two patches with the same class name do not get created
      *
-     * @param $name
+     * @param  string $name
      *
      * @throws FileNotFoundException
      */
-    protected function ensurePatchDoesntAlreadyExist($name): void
+    protected function ensurePatchDoesntAlreadyExist(string $name): void
     {
         $patchesPath = $this->patcher->getPatchPath();
 
@@ -169,12 +140,12 @@ class PatchMakeCommand extends Command
     /**
      * Get the path of the file to be created
      *
-     * @param $name
-     * @param $path
+     * @param  string  $name
+     * @param  string  $path
      *
      * @return string
      */
-    protected function getPath($name, $path): string
+    protected function getPath(string $name, string $path): string
     {
         return $path.'/'.$this->getDatePrefix().'_'.$name.'.php';
     }
@@ -182,9 +153,9 @@ class PatchMakeCommand extends Command
     /**
      * Get the date prefix of the file
      *
-     * @return false|string
+     * @return string
      */
-    protected function getDatePrefix()
+    protected function getDatePrefix(): string
     {
         return date('Y_m_d_His');
     }
@@ -192,12 +163,12 @@ class PatchMakeCommand extends Command
     /**
      * Replace the placeholders in the stub with their actual data
      *
-     * @param $name
-     * @param $stub
+     * @param  string  $name
+     * @param  string  $stub
      *
-     * @return string|string[]
+     * @return string
      */
-    protected function populateStub($name, $stub)
+    protected function populateStub(string $name, string $stub): string
     {
         return str_replace('{{ class }}', $this->patcher->getClassName($name), $stub);
     }

--- a/src/Commands/RollbackCommand.php
+++ b/src/Commands/RollbackCommand.php
@@ -147,7 +147,9 @@ class RollbackCommand extends Command
      */
     protected function runDown($file, object $patch): void
     {
-        $instance = $this->patcher->resolve($name = $this->patcher->getPatchName($file));
+        $instance = $this->patcher->resolve($file);
+
+        $name = $this->patcher->getPatchName($file);
 
         $this->line("<comment>Rolling back:</comment> {$name}");
 

--- a/src/Commands/RollbackCommand.php
+++ b/src/Commands/RollbackCommand.php
@@ -6,6 +6,7 @@ use Illuminate\Console\Command;
 use Illuminate\Console\ConfirmableTrait;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Support\Arr;
+use Rappasoft\LaravelPatches\Models\Patch;
 use Rappasoft\LaravelPatches\Patcher;
 use Rappasoft\LaravelPatches\Repository;
 
@@ -33,31 +34,14 @@ class RollbackCommand extends Command
     protected $description = 'Rollback the last patch';
 
     /**
-     * The patcher instance.
-     *
-     * @var Patcher
-     */
-    protected Patcher $patcher;
-
-    /**
-     * The repository instance.
-     *
-     * @var Repository
-     */
-    protected Repository $repository;
-
-    /**
      * PatchCommand constructor.
      *
      * @param  Patcher  $patcher
      * @param  Repository  $repository
      */
-    public function __construct(Patcher $patcher, Repository $repository)
+    public function __construct(protected Patcher $patcher, protected Repository $repository)
     {
         parent::__construct();
-
-        $this->patcher = $patcher;
-        $this->repository = $repository;
     }
 
     /**
@@ -80,7 +64,7 @@ class RollbackCommand extends Command
     /**
      * Rollback the appropriate patches
      *
-     * @return array
+     * @return string[]
      * @throws FileNotFoundException
      */
     protected function rollback(): array
@@ -99,20 +83,18 @@ class RollbackCommand extends Command
     /**
      * Decide which patch files to rollback and run their down methods
      *
-     * @param $patches
+     * @param  Patch[]  $patches
      *
-     * @return array
+     * @return string[]
      * @throws FileNotFoundException
      */
-    protected function rollbackPatches($patches): array
+    protected function rollbackPatches(array $patches): array
     {
         $rolledBack = [];
 
         $this->patcher->requireFiles($files = $this->patcher->getPatchFiles($this->patcher->getPatchPaths()));
 
         foreach ($patches as $patch) {
-            $patch = (object) $patch;
-
             if (! $file = Arr::get($files, $patch->patch)) {
                 $this->line("<fg=red>Patch not found:</> {$patch->patch}");
 
@@ -130,7 +112,7 @@ class RollbackCommand extends Command
     /**
      * Decide which patch files to choose for rollback based on passed in options
      *
-     * @return array
+     * @return Patch[]
      */
     protected function getPatchesForRollback(): array
     {
@@ -142,10 +124,10 @@ class RollbackCommand extends Command
     /**
      * Run the down method on the patch
      *
-     * @param $file
+     * @param  string  $file
      * @param  object  $patch
      */
-    protected function runDown($file, object $patch): void
+    protected function runDown(string $file, object $patch): void
     {
         $instance = $this->patcher->resolve($file);
 

--- a/src/Commands/stubs/patch.stub
+++ b/src/Commands/stubs/patch.stub
@@ -2,36 +2,20 @@
 
 use Rappasoft\LaravelPatches\Patch;
 
-class {{ class }} extends Patch
-{
+return new class extends Patch {
     /**
      * Run the patch.
-     *
-     * @return void
      */
-    public function up()
+    public function up(): void
     {
-        info('Hello!');
-
-        // Useful methods
-//        $this->log('Hello');
-//        $this->call('my-command', ['my-option' => 'my-value']);
-//        $this->seed('PatchV1_0_0Seeder');
-//        $this->truncate('my-table');
+        //
     }
 
     /**
      * Reverse the patch.
-     *
-     * @return void
      */
-    public function down()
+    public function down(): void
     {
-        info('Goodbye :(');
-
-        // Useful methods
-//        $this->call('my-command', ['my-option' => 'my-value']);
-//        $this->seed('PatchV1_0_0Seeder');
-//        $this->truncate('my-table');
+        //
     }
-}
+};

--- a/src/Models/Patch.php
+++ b/src/Models/Patch.php
@@ -45,7 +45,7 @@ class Patch extends Model
      *
      * @return string
      */
-    public function getTable()
+    public function getTable(): string
     {
         return config('laravel-patches.table_name');
     }

--- a/src/Patch.php
+++ b/src/Patch.php
@@ -13,19 +13,19 @@ use Illuminate\Support\Facades\DB;
 abstract class Patch
 {
     /**
-     * @var array
+     * @var string[]
      */
     public array $log = [];
 
     /**
      * Call an Artisan command
      *
-     * @param $command
+     * @param  string  $command
      * @param  array  $parameters
      *
      * @return int
      */
-    public function call($command, array $parameters = []): int
+    public function call(string $command, array $parameters = []): int
     {
         return Artisan::call($command, $parameters);
     }
@@ -45,7 +45,7 @@ abstract class Patch
     /**
      * Truncate a table by name
      *
-     * @param string $table
+     * @param  string  $table
      */
     public function truncate(string $table): void
     {
@@ -55,9 +55,9 @@ abstract class Patch
     /**
      * Add to the commands logged output
      *
-     * @param  string  $line
+     * @param string $line
      *
-     * @return $this
+     * @return Patch
      */
     public function log(string $line): Patch
     {

--- a/src/Patcher.php
+++ b/src/Patcher.php
@@ -17,25 +17,12 @@ use Symfony\Component\Console\Output\OutputInterface;
 class Patcher
 {
     /**
-     * The filesystem instance.
-     *
-     * @var Filesystem
-     */
-    protected Filesystem $files;
-
-    /**
      * @var OutputInterface
      */
     protected OutputInterface $output;
 
-    /**
-     * Patcher constructor.
-     *
-     * @param  Filesystem  $files
-     */
-    public function __construct(Filesystem $files)
+    public function __construct(protected Filesystem $files)
     {
-        $this->files = $files;
     }
 
     /**
@@ -64,7 +51,7 @@ class Patcher
     /**
      * Return the array of paths to look through for patches
      *
-     * @return array
+     * @return string[]
      */
     public function getPatchPaths(): array
     {
@@ -82,11 +69,11 @@ class Patcher
     }
 
     /**
-     * @param $paths
+     * @param  string[] $paths
      *
-     * @return array
+     * @return string[]
      */
-    public function getPatchFiles($paths): array
+    public function getPatchFiles(array $paths): array
     {
         return collect($paths)
             ->flatMap(fn ($path) => Str::endsWith($path, '.php') ? [$path] : $this->files->glob($path.'/*_*.php'))
@@ -100,11 +87,11 @@ class Patcher
     /**
      * Get the ClassName
      *
-     * @param $name
+     * @param  string $name
      *
      * @return string
      */
-    public function getClassName($name): string
+    public function getClassName(string $name): string
     {
         return Str::studly($name);
     }
@@ -124,7 +111,7 @@ class Patcher
     /**
      * Require in all the patch files in a given path.
      *
-     * @param  array  $files
+     * @param  string[]  $files
      *
      * @return void
      * @throws FileNotFoundException
@@ -161,7 +148,7 @@ class Patcher
      * @param  object  $patch
      * @param  string  $method
      *
-     * @return array
+     * @return string[]|null
      */
     public function runPatch(object $patch, string $method): ?array
     {

--- a/src/Patcher.php
+++ b/src/Patcher.php
@@ -2,6 +2,7 @@
 
 namespace Rappasoft\LaravelPatches;
 
+use Error;
 use Illuminate\Contracts\Filesystem\FileNotFoundException;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Schema;
@@ -144,9 +145,14 @@ class Patcher
      */
     public function resolve(string $file): object
     {
-        $class = Str::studly(implode('_', array_slice(explode('_', $file), 4)));
+        $name = $this->getPatchName($file);
+        $class = Str::studly(implode('_', array_slice(explode('_', $name), 4)));
 
-        return new $class;
+        try {
+            return new $class;
+        } catch (Error $e) {
+            return require $file;
+        }
     }
 
     /**

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -16,7 +16,7 @@ class Repository
      *
      * @param  int  $steps
      *
-     * @return array
+     * @return Patch[]
      */
     public function getPatches(int $steps): array
     {
@@ -61,9 +61,7 @@ class Repository
      *
      * @param  string  $file
      * @param  int  $batch
-     * @param  array  $log
-     *
-     * @return void
+     * @param  string[]  $log
      */
     public function log(string $file, int $batch, array $log = []): void
     {
@@ -98,7 +96,7 @@ class Repository
     /**
      * Get the last patch batch number.
      *
-     * @return int
+     * @return int|null
      */
     public function getLastBatchNumber(): ?int
     {

--- a/tests/Commands/PatchMakeTest.php
+++ b/tests/Commands/PatchMakeTest.php
@@ -3,7 +3,6 @@
 namespace Rappasoft\LaravelPatches\Tests\Commands;
 
 use Illuminate\Support\Facades\File;
-use InvalidArgumentException;
 use Rappasoft\LaravelPatches\Tests\TestCase;
 
 class PatchMakeTest extends TestCase
@@ -25,14 +24,5 @@ class PatchMakeTest extends TestCase
         foreach (glob(database_path('patches').'/*') as $file) {
             $this->assertTrue(filesize($file) > 0);
         }
-    }
-
-    /** @test */
-    public function it_doesnt_make_two_patches_with_the_same_name()
-    {
-        $this->expectException(InvalidArgumentException::class);
-
-        $this->artisan('make:patch', ['name' => 'new_patch'])->run();
-        $this->artisan('make:patch', ['name' => 'new_patch'])->run();
     }
 }

--- a/tests/Commands/PatchTest.php
+++ b/tests/Commands/PatchTest.php
@@ -13,12 +13,16 @@ class PatchTest extends TestCase
             database_path('patches/2021_01_01_000000_my_first_patch.php'),
             file_get_contents(__DIR__.'/patches/2021_01_01_000000_my_first_patch.php')
         );
+        file_put_contents(
+            database_path('patches/2021_01_03_000000_my_third_patch.php'),
+            file_get_contents(__DIR__.'/patches/2021_01_03_000000_my_third_patch.php')
+        );
 
         $this->assertDatabaseCount(config('laravel-patches.table_name'), 0);
 
         $this->artisan('patch')->run();
 
-        $this->assertDatabaseCount(config('laravel-patches.table_name'), 1);
+        $this->assertDatabaseCount(config('laravel-patches.table_name'), 2);
 
         $this->assertDatabaseHas(config('laravel-patches.table_name'), [
             'patch' => '2021_01_01_000000_my_first_patch',

--- a/tests/Commands/patches/2021_01_01_000000_my_first_patch.php
+++ b/tests/Commands/patches/2021_01_01_000000_my_first_patch.php
@@ -9,7 +9,7 @@ class MyFirstPatch extends Patch
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         $this->log('Hello First!');
     }
@@ -19,7 +19,7 @@ class MyFirstPatch extends Patch
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         \Log::info('Goodbye First');
     }

--- a/tests/Commands/patches/2021_01_02_000000_my_second_patch.php
+++ b/tests/Commands/patches/2021_01_02_000000_my_second_patch.php
@@ -9,7 +9,7 @@ class MySecondPatch extends Patch
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         $this->log('Hello Second!');
     }
@@ -19,7 +19,7 @@ class MySecondPatch extends Patch
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         \Log::info('Goodbye Second');
     }

--- a/tests/Commands/patches/2021_01_03_000000_my_third_patch.php
+++ b/tests/Commands/patches/2021_01_03_000000_my_third_patch.php
@@ -2,14 +2,13 @@
 
 use Rappasoft\LaravelPatches\Patch;
 
-class MyThirdPatch extends Patch
-{
+return new class extends Patch {
     /**
      * Run the patch.
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         $this->log('Hello Third!');
     }
@@ -19,8 +18,8 @@ class MyThirdPatch extends Patch
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
         \Log::info('Goodbye Third');
     }
-}
+};

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -41,8 +41,8 @@ class TestCase extends Orchestra
             'prefix' => '',
         ]);
 
-        include_once __DIR__.'/../database/migrations/create_patches_table.php.stub';
-        (new \CreatePatchesTable())->up();
+        $migration = include __DIR__.'/../database/migrations/create_patches_table.php.stub';
+        $migration->up();
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,6 +2,7 @@
 
 namespace Rappasoft\LaravelPatches\Tests;
 
+use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Orchestra\Testbench\TestCase as Orchestra;
 use Rappasoft\LaravelPatches\LaravelPatchesServiceProvider;
@@ -18,11 +19,11 @@ class TestCase extends Orchestra
     }
 
     /**
-     * @param  \Illuminate\Foundation\Application  $app
+     * @param  Application  $app
      *
      * @return string[]
      */
-    protected function getPackageProviders($app)
+    protected function getPackageProviders($app): array
     {
         return [
             LaravelPatchesServiceProvider::class,
@@ -30,9 +31,9 @@ class TestCase extends Orchestra
     }
 
     /**
-     * @param  \Illuminate\Foundation\Application  $app
+     * @param  Application  $app
      */
-    public function getEnvironmentSetUp($app)
+    public function getEnvironmentSetUp($app): void
     {
         $app['config']->set('database.default', 'sqlite');
         $app['config']->set('database.connections.sqlite', [


### PR DESCRIPTION
This PR updates the generated code to align with Laravel’s current approach for migrations. Laravel has long adopted anonymous classes for migrations to prevent class name collisions. With this change, you can now generate migrations using:

```shell
php artisan make:patch update_users
php artisan make:patch update_users
```

The generated patches are now cleaner, with unnecessary long comments removed, as documentation is a more appropriate place for them.

The library still supports the older patch structure for those who already have them in their projects.

Additionally, this PR removes support for PHP 8.0, which reached its end of life.